### PR TITLE
Minor refinements

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/Aiven-Open/nomad-droplets-autoscaler/plugin"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-hclog"
@@ -13,5 +15,5 @@ func main() {
 }
 
 func factory(log hclog.Logger) interface{} {
-	return plugin.NewDODropletsPlugin(log)
+	return plugin.NewDODropletsPlugin(context.Background(), log)
 }

--- a/plugin/digitalocean.go
+++ b/plugin/digitalocean.go
@@ -108,10 +108,10 @@ func (t *TargetPlugin) scaleIn(
 	}
 
 	// Grab the instanceIDs
-	instanceIDs := map[string]bool{}
+	instanceIDs := make(map[string]struct{})
 
 	for _, node := range ids {
-		instanceIDs[node.RemoteResourceID] = true
+		instanceIDs[node.RemoteResourceID] = struct{}{}
 	}
 
 	// Create a logger for this action to pre-populate useful information we
@@ -160,7 +160,7 @@ func (t *TargetPlugin) ensureDropletsAreStable(
 func (t *TargetPlugin) deleteDroplets(
 	ctx context.Context,
 	tag string,
-	instanceIDs map[string]bool,
+	instanceIDs map[string]struct{},
 ) error {
 	// create options. initially, these will be blank
 	var dropletsToDelete []int

--- a/plugin/shutdown.go
+++ b/plugin/shutdown.go
@@ -10,25 +10,27 @@ import (
 )
 
 func shutdownDroplet(
+	ctx context.Context,
 	dropletId int,
 	client *godo.Client,
-	log hclog.Logger) error {
-
+	log hclog.Logger,
+) error {
 	// Gracefully power off the droplet.
 	log.Debug("Gracefully shutting down droplet...")
-	_, _, err := client.DropletActions.PowerOff(context.TODO(), dropletId)
+	_, _, err := client.DropletActions.PowerOff(ctx, dropletId)
 	if err != nil {
-		// If we get an error the first time, actually report it
 		return fmt.Errorf("error shutting down droplet: %s", err)
 	}
 
-	err = waitForDropletState("off", dropletId, client, log, 5*time.Minute)
+	ctxWaitForDropletState, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	err = waitForDropletState(ctxWaitForDropletState, "off", dropletId, client, log)
 	if err != nil {
-		log.Warn("Timeout while waiting to for droplet to become 'off'")
+		log.Warn("Timeout while waiting to for droplet to become 'off'", "error", err)
 	}
 
 	log.Debug("Deleting Droplet...")
-	_, err = client.Droplets.Delete(context.TODO(), dropletId)
+	_, err = client.Droplets.Delete(ctx, dropletId)
 	if err != nil {
 		return fmt.Errorf("error deleting droplet: %s", err)
 	}


### PR DESCRIPTION
Rather than creating each droplet in series, allow these operations to be performed concurrently.

Make a few other small internal changes relating to how context is used (instead of sleep) and how maps are used as sets.